### PR TITLE
feat: add `ssh` package

### DIFF
--- a/internal/ssh/client.go
+++ b/internal/ssh/client.go
@@ -1,0 +1,89 @@
+package ssh
+
+import (
+	"fmt"
+	"os"
+	"path"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
+	"neite.dev/go-ship/internal/config"
+)
+
+type Client struct {
+	conn *ssh.Client
+}
+
+func NewConnection(cfg *config.UserConfig) (*Client, error) {
+	homedir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+	hostkeyCallback, err := knownhosts.New(path.Join(homedir, ".ssh", "known_hosts"))
+	if err != nil {
+		return nil, err
+	}
+
+	key, err := os.ReadFile(path.Join(homedir, ".ssh", "id_rsa"))
+	if err != nil {
+		return nil, err
+	}
+
+	signer, err := ssh.ParsePrivateKey(key)
+	if err != nil {
+		return nil, err
+	}
+
+	config := &ssh.ClientConfig{
+		User: "root",
+		Auth: []ssh.AuthMethod{
+			ssh.PublicKeys(signer),
+		},
+		HostKeyCallback: hostkeyCallback,
+	}
+
+	addr := formatAddress(cfg.Server, *cfg.SSH.Port)
+	conn, err := ssh.Dial("tcp", addr, config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Client{conn: conn}, nil
+}
+
+func (c *Client) NewSession(opts ...sshOption) (*Session, error) {
+	var options sessionOptions
+	for _, opt := range opts {
+		err := opt(&options)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	sshSess, err := c.conn.NewSession()
+	if err != nil {
+		return nil, err
+	}
+
+	if options.stdout != nil {
+		sshSess.Stdout = options.stdout
+	}
+
+	if options.stderr != nil {
+		sshSess.Stderr = options.stderr
+	}
+
+	session := Session{
+		sshSess: sshSess,
+	}
+
+	return &session, nil
+}
+
+func (c *Client) Close() error {
+	return c.conn.Close()
+}
+
+func formatAddress(ip string, port int) string {
+	return fmt.Sprintf("%s:%d", ip, port)
+}

--- a/internal/ssh/session.go
+++ b/internal/ssh/session.go
@@ -1,0 +1,48 @@
+package ssh
+
+import (
+	"errors"
+	"io"
+
+	"golang.org/x/crypto/ssh"
+)
+
+type sshOption func(options *sessionOptions) error
+
+type sessionOptions struct {
+	stdout io.Writer
+	stderr io.Writer
+}
+
+type Session struct {
+	sshSess *ssh.Session
+}
+
+func WithStdout(stdout io.Writer) sshOption {
+	return func(options *sessionOptions) error {
+		if stdout == nil {
+			return errors.New("stdout pipe could not be set to nil")
+		}
+		options.stdout = stdout
+		return nil
+	}
+}
+
+func WithStderr(stderr io.Writer) sshOption {
+	return func(options *sessionOptions) error {
+		if stderr == nil {
+			return errors.New("stderr pipe could not be set to nil")
+		}
+		options.stdout = stderr
+		return nil
+	}
+}
+
+func (s Session) Run(cmd string) error {
+	return s.sshSess.Run(cmd)
+
+}
+
+func (s Session) Close() error {
+	return s.sshSess.Close()
+}


### PR DESCRIPTION
basically wrap `golang.org/x/crypto/ssh` into our own package for easier
access to underlying api